### PR TITLE
"Computer Modern" not global default font

### DIFF
--- a/src/hysteresis_sweep.jl
+++ b/src/hysteresis_sweep.jl
@@ -89,7 +89,7 @@ function plot_1D_solutions_branch(starting_branch::Int64,res::Result; x::String,
 
     Y_followed = [Ys[branch,param_idx] for (param_idx,branch) in enumerate(followed_branch)]
 
-    lines = plot(transform_solutions(res, x),Y_followed,c="k",marker=m; kwargs...)   
+    lines = plot(transform_solutions(res, x),Y_followed,c="k",marker=m; _set_Plots_default..., kwargs...)   
     
     #extract plotted data and return it
     xdata,ydata = [line.get_xdata() for line in lines], [line.get_ydata() for line in lines]

--- a/src/modules/LinearResponse/plotting.jl
+++ b/src/modules/LinearResponse/plotting.jl
@@ -63,7 +63,7 @@ C = order == 1 ? get_jacobian_response(res, nat_var, Ω_range, branch) : get_lin
 C = logscale ? log.(C) : C
 
 heatmap(X, Ω_range,  C; color=:viridis, 
-    xlabel=latexify(string(first(keys(res.swept_parameters)))), ylabel=latexify("Ω"), kwargs...)
+    xlabel=latexify(string(first(keys(res.swept_parameters)))), ylabel=latexify("Ω"), _set_Plots_default..., kwargs...)
 end
 
 

--- a/src/modules/TimeEvolution/ODEProblem.jl
+++ b/src/modules/TimeEvolution/ODEProblem.jl
@@ -88,11 +88,10 @@ Parametric plot of f[1] against f[2]
 
 """
 function plot(soln::OrdinaryDiffEq.ODECompositeSolution, funcs, harm_eq::HarmonicEquation; kwargs...)
-    HarmonicBalance._set_Plots_default()
     if funcs isa String || length(funcs) == 1
-        plot(soln.t, transform_solutions(soln, funcs, harm_eq); legend=false, xlabel="time", ylabel=latexify(funcs), kwargs...)
+        plot(soln.t, transform_solutions(soln, funcs, harm_eq); legend=false, xlabel="time", ylabel=latexify(funcs), _set_Plots_default..., kwargs...)
     elseif length(funcs) == 2 # plot of func vs func
-        plot(transform_solutions(soln, funcs, harm_eq)...; legend=false, xlabel=latexify(funcs[1]), ylabel=latexify(funcs[2]), kwargs...)
+        plot(transform_solutions(soln, funcs, harm_eq)...; legend=false, xlabel=latexify(funcs[1]), ylabel=latexify(funcs[2]), _set_Plots_default..., kwargs...)
     else
         error("Invalid plotting argument: ", funcs)
     end

--- a/src/plotting_Plots.jl
+++ b/src/plotting_Plots.jl
@@ -1,11 +1,14 @@
 using Plots, Latexify
 import Plots.plot, Plots.plot!; export plot, plot!, plot_phase_diagram, savefig
 
-function _set_Plots_default()
-    # font = "Computer Modern"
-    default(linewidth=2, legend=:outerright)
-    # default(fontfamily=font, titlefont=font , tickfont=font)
-end
+const _set_Plots_default = Dict{Symbol, Any}([
+    :fontfamily => "computer modern",
+    :titlefont => "computer modern",
+    :tickfont => "computer modern",
+    :linewidth => 2,
+    :legend => :outerright])
+
+
 
 dim(res::Result) = length(size(res.solutions)) # give solution dimensionality
 
@@ -39,12 +42,11 @@ default behaviour: plot stable solutions as full lines, unstable as dashed
 
 the x and y axes are taken automatically from `res`
 """
-function plot(res::Result, varargs...; fontfamily="Computer Modern", titlefont="Computer Modern" , tickfont="Computer Modern", kwargs...)::Plots.Plot
-    HarmonicBalance._set_Plots_default()
+function plot(res::Result, varargs...; kwargs...)::Plots.Plot
     if dim(res) == 1
-        plot1D(res, varargs...; fontfamily=fontfamily, titlefont=titlefont , tickfont=tickfont, kwargs...)
+        plot1D(res, varargs...; _set_Plots_default..., kwargs...)
     elseif dim(res) == 2
-        plot2D(res, varargs...; fontfamily=fontfamily, titlefont=titlefont , tickfont=tickfont, kwargs...)
+        plot2D(res, varargs...; _set_Plots_default..., kwargs...)
     else
         error("Data dimension ", dim(res), " not supported")
     end
@@ -56,8 +58,8 @@ $(TYPEDSIGNATURES)
 
 Similar to `plot` but adds a plot onto an existing plot.
 """
-function plot!(res::Result, varargs...; fontfamily="Computer Modern", titlefont="Computer Modern" , tickfont="Computer Modern",  kwargs...)::Plots.Plot
-    plot(res, varargs...; add=true, fontfamily=fontfamily, titlefont=titlefont , tickfont=tickfont,  kwargs...)
+function plot!(res::Result, varargs...; kwargs...)::Plots.Plot
+    plot(res, varargs...; add=true, _set_Plots_default..., kwargs...)
 end
 """
 $(TYPEDSIGNATURES)
@@ -166,12 +168,11 @@ Class selection done by passing `String` or `Vector{String}` as kwarg:
 
 Other kwargs are passed onto Plots.gr()
 """
-function plot_phase_diagram(res::Result; fontfamily="Computer Modern", titlefont="Computer Modern" , tickfont="Computer Modern", kwargs...)::Plots.Plot
-    _set_Plots_default()
+function plot_phase_diagram(res::Result; kwargs...)::Plots.Plot
     if dim(res) == 1
-        plot_phase_diagram_1D(res; fontfamily=fontfamily, titlefont=titlefont , tickfont=tickfont, kwargs...)
+        plot_phase_diagram_1D(res; _set_Plots_default..., kwargs...)
     elseif dim(res) == 2
-        plot_phase_diagram_2D(res; fontfamily=fontfamily, titlefont=titlefont , tickfont=tickfont, kwargs...)
+        plot_phase_diagram_2D(res; _set_Plots_default..., kwargs...)
     else
         error("Data dimension ", dim(res), " not supported")
     end

--- a/src/plotting_Plots.jl
+++ b/src/plotting_Plots.jl
@@ -2,9 +2,9 @@ using Plots, Latexify
 import Plots.plot, Plots.plot!; export plot, plot!, plot_phase_diagram, savefig
 
 function _set_Plots_default()
-    font = "Computer Modern"
+    # font = "Computer Modern"
     default(linewidth=2, legend=:outerright)
-    default(fontfamily=font, titlefont=font , tickfont=font)
+    # default(fontfamily=font, titlefont=font , tickfont=font)
 end
 
 dim(res::Result) = length(size(res.solutions)) # give solution dimensionality
@@ -39,12 +39,12 @@ default behaviour: plot stable solutions as full lines, unstable as dashed
 
 the x and y axes are taken automatically from `res`
 """
-function plot(res::Result, varargs...; kwargs...)::Plots.Plot
+function plot(res::Result, varargs...; fontfamily="Computer Modern", titlefont="Computer Modern" , tickfont="Computer Modern", kwargs...)::Plots.Plot
     HarmonicBalance._set_Plots_default()
     if dim(res) == 1
-        plot1D(res, varargs...; kwargs...)
+        plot1D(res, varargs...; fontfamily=fontfamily, titlefont=titlefont , tickfont=tickfont, kwargs...)
     elseif dim(res) == 2
-        plot2D(res, varargs...; kwargs...)
+        plot2D(res, varargs...; fontfamily=fontfamily, titlefont=titlefont , tickfont=tickfont, kwargs...)
     else
         error("Data dimension ", dim(res), " not supported")
     end
@@ -56,9 +56,9 @@ $(TYPEDSIGNATURES)
 
 Similar to `plot` but adds a plot onto an existing plot.
 """
-plot!(res::Result, varargs...; kwargs...)::Plots.Plot = plot(res, varargs...; add=true, kwargs...)
-
-
+function plot!(res::Result, varargs...; fontfamily="Computer Modern", titlefont="Computer Modern" , tickfont="Computer Modern",  kwargs...)::Plots.Plot
+    plot(res, varargs...; add=true, fontfamily=fontfamily, titlefont=titlefont , tickfont=tickfont,  kwargs...)
+end
 """
 $(TYPEDSIGNATURES)
 
@@ -166,12 +166,12 @@ Class selection done by passing `String` or `Vector{String}` as kwarg:
 
 Other kwargs are passed onto Plots.gr()
 """
-function plot_phase_diagram(res::Result; kwargs...)::Plots.Plot
+function plot_phase_diagram(res::Result; fontfamily="Computer Modern", titlefont="Computer Modern" , tickfont="Computer Modern", kwargs...)::Plots.Plot
     _set_Plots_default()
     if dim(res) == 1
-        plot_phase_diagram_1D(res; kwargs...)
+        plot_phase_diagram_1D(res; fontfamily=fontfamily, titlefont=titlefont , tickfont=tickfont, kwargs...)
     elseif dim(res) == 2
-        plot_phase_diagram_2D(res; kwargs...)
+        plot_phase_diagram_2D(res; fontfamily=fontfamily, titlefont=titlefont , tickfont=tickfont, kwargs...)
     else
         error("Data dimension ", dim(res), " not supported")
     end


### PR DESCRIPTION
The solution to issue #49:
HarmonicBalance does not define "Computer Modern" is the the global default font. Yet only the HarmonicBalance plot functions will use Computer modern by "default".

I tested the code with the Duffing oscillator example:
```julia
using HarmonicBalance
@variables α, ω, ω0, F, t, γ, x(t) # declare constant variables and a function x(t)
diff_eq = DifferentialEquation(d(x,t,2) + ω0^2*x + α*x^3 + γ*d(x,t) ~ F*cos(ω*t), x) #declare differential equation
add_harmonic!(diff_eq, x, ω) # specify the ansatz x = u(T) cos(ωt) + v(T) sin(ωt)
harmonic_eq = get_harmonic_equations(diff_eq)
varied = ω => LinRange(0.9, 1.2, 100) # range of parameter values
fixed = (α => 1., ω0 => 1.0, F => 0.01, γ=>0.01) # fixed parameters
solutions = get_steady_states(harmonic_eq, varied, fixed)
plot(solutions, x="ω", y="sqrt(u1^2 + v1^2)")
plot_phase_diagram(solutions)

x = -5:0.1:5
plot(x, x.^2)
```