### PR TITLE
Raised the neglectable threshold when plotting the steady states

### DIFF
--- a/src/HarmonicBalance.jl
+++ b/src/HarmonicBalance.jl
@@ -25,7 +25,7 @@ module HarmonicBalance
    end
 
    export is_real
-    is_real(x) = abs(imag(x)) / abs(real(x)) < im_tol::Float64 || abs(x) < 1E-70
+    is_real(x) = abs(imag(x)) / abs(real(x)) < im_tol::Float64 || abs(x) < 1e-20
     is_real(x::Array) = any(is_real.(x))
 
     # Symbolics does not natively support complex exponentials of variables

--- a/src/HarmonicBalance.jl
+++ b/src/HarmonicBalance.jl
@@ -19,13 +19,13 @@ module HarmonicBalance
 
    # default global settings
    export im_tol
-   im_tol = 1E-6
+   im_tol::Float64 = 1E-6
    function set_imaginary_tolerance(x::Float64)
-       @eval(im_tol = $x)
+       @eval(im_tol::Float64 = $x)
    end
 
    export is_real
-    is_real(x) = abs(imag(x)) / abs(real(x)) < im_tol || abs(x) < 1E-70
+    is_real(x) = abs(imag(x)) / abs(real(x)) < im_tol::Float64 || abs(x) < 1E-70
     is_real(x::Array) = any(is_real.(x))
 
     # Symbolics does not natively support complex exponentials of variables

--- a/src/HarmonicBalance.jl
+++ b/src/HarmonicBalance.jl
@@ -18,14 +18,14 @@ module HarmonicBalance
     Float64(x::Num) = Float64(x.val)
 
    # default global settings
-   export im_tol
-   im_tol::Float64 = 1E-6
+   export IM_TOL
+   IM_TOL::Float64 = 1E-6
    function set_imaginary_tolerance(x::Float64)
-       @eval(im_tol::Float64 = $x)
+       @eval(IM_TOL::Float64 = $x)
    end
 
    export is_real
-    is_real(x) = abs(imag(x)) / abs(real(x)) < im_tol::Float64 || abs(x) < 1e-20
+    is_real(x) = abs(imag(x)) / abs(real(x)) < IM_TOL::Float64 || abs(x) < 1e-20
     is_real(x::Array) = any(is_real.(x))
 
     # Symbolics does not natively support complex exponentials of variables

--- a/src/classification.jl
+++ b/src/classification.jl
@@ -73,7 +73,7 @@ $(TYPEDSIGNATURES)
 Returns true if the solution `soln` of the Result `res` is physical (= real number).
 `im_tol` : an absolute threshold to distinguish real/complex numbers.
 """
-function is_physical(soln::StateDict, res::Result; im_tol=im_tol)
+function is_physical(soln::StateDict, res::Result; im_tol=IM_TOL)
     var_values = [getindex(soln, v) for v in res.problem.variables]
     return all(abs.(imag.(var_values)).<im_tol) && any(isnan.(var_values).==false)
 end
@@ -86,7 +86,7 @@ Stable solutions are real and have all Jacobian eigenvalues Re[λ] <= 0.
 `im_tol` : an absolute threshold to distinguish real/complex numbers.
 `rel_tol`: Re(λ) considered <=0 if real.(λ) < rel_tol*abs(λmax)
 """
-function is_stable(soln::StateDict, res::Result; im_tol=im_tol, rel_tol=1E-10)
+function is_stable(soln::StateDict, res::Result; im_tol=IM_TOL, rel_tol=1E-10)
     is_physical(soln, res ,im_tol=im_tol) || return false  # the solution is unphysical anyway
     λs = eigvals(real.(res.jacobian(soln)))
     return all([real.(λs) .< rel_tol*maximum(abs.(λs))]...)
@@ -100,7 +100,7 @@ Hopf-unstable solutions are real and have exactly two Jacobian eigenvalues with 
 are complex conjugates of each other.
 `im_tol` : an absolute threshold to distinguish real/complex numbers.
 """
-function is_Hopf_unstable(soln::StateDict, res::Result; im_tol=im_tol)
+function is_Hopf_unstable(soln::StateDict, res::Result; im_tol=IM_TOL)
     is_physical(soln, res, im_tol=im_tol) || return false  # the solution is unphysical anyway
     J = res.jacobian(soln)
     unstable = filter(x -> real(x) > 0, eigvals(J))


### PR DESCRIPTION
partially solution of issue #61 

I also changed the global `im_tol` to be typed, as suggested by the [julia documentation](https://docs.julialang.org/en/v1/manual/performance-tips/), and changed the name to all capital letters, as suggested by the [style guide](https://docs.sciml.ai/SciMLStyle/dev/) of SCIML.

At a quick glance, I not managed to ensure that the warning is only shown once every time the plot function is evoked.

It would be good to add a note about this issue in the documentation.
