### PR TITLE
plotting branches, optimized sorting, deps removed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,7 +37,7 @@ Peaks = "0.4.1"
 Plots = "1.36.4"
 ProgressMeter = "1.7.2"
 Symbolics = "4.13.0"
-julia = "1.8.3"
+julia = "1.8.2"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HarmonicBalance"
 uuid = "e13b9ff6-59c3-11ec-14b1-f3d2cc6c135e"
 authors = ["Jan Kosata <kosataj@phys.ethz.ch>", "Javier del Pino <jdelpino@phys.ethz.ch>"]
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 BijectiveHilbert = "91e7fc40-53cd-4118-bd19-d7fcd1de2a54"

--- a/src/HarmonicBalance.jl
+++ b/src/HarmonicBalance.jl
@@ -26,7 +26,7 @@ module HarmonicBalance
 
    export is_real
     is_real(x) = abs(imag(x)) / abs(real(x)) < IM_TOL::Float64 || abs(x) < 1e-70
-    is_real(x::Array) = any(is_real.(x))
+    is_real(x::Array) = is_real.(x)
 
     # Symbolics does not natively support complex exponentials of variables
     import Base: exp

--- a/src/HarmonicEquation.jl
+++ b/src/HarmonicEquation.jl
@@ -134,6 +134,7 @@ end
 
 
 get_variables(p::Problem) = get_variables(p.eom)
+get_variables(res::Result) = get_variables(res.problem)
 
 
 "Get the parameters (not time nor variables) of a HarmonicEquation"

--- a/src/HarmonicVariable.jl
+++ b/src/HarmonicVariable.jl
@@ -1,5 +1,4 @@
 import Symbolics: get_variables; export get_variables
-import Base.isequal; export isequal
 
 # pretty-printing
 display(var::HarmonicVariable) = display(var.name)
@@ -46,7 +45,7 @@ get_variables(vars::Vector{Num}) = unique(flatten([Num.(get_variables(x)) for x 
 
 get_variables(var::HarmonicVariable) = Num.(get_variables(var.symbol))
 
-isequal(v1::HarmonicVariable, v2::HarmonicVariable) = isequal(v1.symbol, v2.symbol)
+Base.isequal(v1::HarmonicVariable, v2::HarmonicVariable) = isequal(v1.symbol, v2.symbol)
 
 
 

--- a/src/modules/LinearResponse.jl
+++ b/src/modules/LinearResponse.jl
@@ -9,7 +9,7 @@ module LinearResponse
     using ..HC_wrapper
     using DocStringExtensions
 
-    import Base: *, show; export *, show
+    import Base: show; export show
 
     include("LinearResponse/types.jl")
     include("LinearResponse/utils.jl")

--- a/src/modules/LinearResponse/Lorentzian_spectrum.jl
+++ b/src/modules/LinearResponse/Lorentzian_spectrum.jl
@@ -2,12 +2,12 @@
 Here the methods to find a
 """
 # multiply a peak by a number.
- function *(number::Float64, peak::Lorentzian) # multiplication operation
+ function Base.:*(number::Float64, peak::Lorentzian) # multiplication operation
     Lorentzian(peak.ω0, peak.Γ, peak.A*number)
  end
 
 
- *(number::Float64, s::JacobianSpectrum) = JacobianSpectrum([number * peak for peak in s.peaks])
+ Base.:*(number::Float64, s::JacobianSpectrum) = JacobianSpectrum([number * peak for peak in s.peaks])
 
 
 function show(io::IO, s::JacobianSpectrum)

--- a/src/modules/TimeEvolution/ODEProblem.jl
+++ b/src/modules/TimeEvolution/ODEProblem.jl
@@ -68,7 +68,7 @@ end
 
 
 transform_solutions(soln::OrdinaryDiffEq.ODESolution, f::String, harm_eq::HarmonicEquation) = transform_solutions(soln.u, f, harm_eq)
-transform_solutions(s::OrdinaryDiffEq.ODESolution, funcs::Vector{String}, harm_eq::HarmonicEquation) = [transform_solutions(s, f, he) for f in funcs]
+transform_solutions(s::OrdinaryDiffEq.ODESolution, funcs::Vector{String}, harm_eq::HarmonicEquation) = [transform_solutions(s, f, harm_eq) for f in funcs]
 
 
 

--- a/src/modules/TimeEvolution/types.jl
+++ b/src/modules/TimeEvolution/types.jl
@@ -1,6 +1,3 @@
-import Base: keys, getindex, +
-export +, getindex
-
 """
 
 Represents a sweep of one or more parameters of a `HarmonicEquation`.
@@ -36,12 +33,12 @@ end
 
 
 # overload so that ParameterSweep can be accessed like a Dict
-keys(s::ParameterSweep) = keys(s.functions)
-getindex(s::ParameterSweep, i) = getindex(s.functions, i)
+Base.keys(s::ParameterSweep) = keys(s.functions)
+Base.getindex(s::ParameterSweep, i) = getindex(s.functions, i)
 
 
 # overload +
-function +(s1::ParameterSweep, s2::ParameterSweep)
+function Base.:+(s1::ParameterSweep, s2::ParameterSweep)
     common_params = intersect(keys(s1), keys(s2))
     !isempty(common_params) && error("cannot combine sweeps of the same parameter")
     return ParameterSweep(merge(s1.functions, s2.functions))

--- a/src/plotting_Plots.jl
+++ b/src/plotting_Plots.jl
@@ -79,8 +79,8 @@ Only `branches` are considered.
 """
 function _get_mask(res, classes, not_classes=[]; branches=1:branch_count(res))
     classes == "all" && return fill(trues(length(branches)), size(res.solutions))
-    bools = vcat([res.classes[c] for c in _vectorise(classes)], [map(.!, res.classes[c]) for c in _vectorise(not_classes)])
-    map( x -> x[_vectorise(branches)], map(.*, bools...))
+    bools = vcat([res.classes[c] for c in _str_to_vec(classes)], [map(.!, res.classes[c]) for c in _str_to_vec(not_classes)])
+    m = map( x -> [getindex(x, b) for b in branches], map(.*, bools...))
 end
 
 
@@ -142,8 +142,8 @@ function _realify(a::Matrix, warn=true)
     return a_real
 end
 
-_vectorise(s::Vector) = s
-_vectorise(s) = [s]
+_str_to_vec(s::Vector) = s
+_str_to_vec(s) = [s]
 
 
 # return true if p already has a label for branch index idx

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -66,10 +66,10 @@ end
 
 "Match each solution from to_sort to a closest partner from refs"
 function get_distance_matrix(refs::Vector{Vector{SteadyState}}, to_sort::Vector{SteadyState})
-    distances = [get_distance_matrix(ref, to_sort) for ref in refs]
+    distances = map( ref -> get_distance_matrix(ref, to_sort), refs)
     lowest_distances = similar(distances[1])
-    for (i, el) in enumerate(lowest_distances)
-        lowest_distances[i] = min([d[i] for d in distances]...)
+    for idx in CartesianIndices(lowest_distances)
+        lowest_distances[idx] = minimum( x[idx] for x in distances )
     end
     lowest_distances
 end

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -77,37 +77,33 @@ end
 
 
 """
-Match a to_sort vector of solutions to a set of reference vector of solutions.
+Match a to_sort vector of solutions to a set of reference vectors of solutions.
 Returns a list of Tuples of the form (1, i1), (2, i2), ... such that
 reference[1] and to_sort[i1] belong to the same branch
 """
-function align_pair(reference::Vector{Vector{SteadyState}}, to_sort::Vector{SteadyState})
-
+function align_pair(reference, to_sort::Vector{SteadyState})
+    
     distances = get_distance_matrix(reference, to_sort)
     n = length(to_sort)
-    cartesians = [(j,i) for i in 1:n for j in 1:n]
-    sorted_cartesians = cartesians[sortperm(vec(distances))]
+    sorted_cartesians = CartesianIndices(distances)[sortperm(vec(distances))]
 
     matched = falses(n)
     matched_ref = falses(n)
 
-    sorted = Array{Tuple{Int64, Int64}, 1}(undef, n)
+    sorted = Vector{CartesianIndex}(undef, n)
 
-    for i in 1:length(cartesians)
-        j,k = sorted_cartesians[i]
+    for idx in sorted_cartesians
+        j,k = idx[1], idx[2]
         if !matched[k] && !matched_ref[j]
             matched[k] = true
             matched_ref[j] = true
-            sorted[j] = (j,k)
+            sorted[j] = idx
         end
     end
 
     return sorted
 
 end
-
-
-align_pair(ref::Vector{SteadyState}, to_sort::Vector{SteadyState}) = align_pair([ref], to_sort)
 
 
 """

--- a/src/transform_solutions.jl
+++ b/src/transform_solutions.jl
@@ -11,34 +11,24 @@ Takes a `Result` object and a string `f` representing a Symbolics.jl expression.
 Returns an array with the values of `f` evaluated for the respective solutions.
 Additional substitution rules can be specified in `rules` in the format `("a" => val)` or `(a => val)`
 """
-function transform_solutions(res::Result, f::String; rules=Dict())
+function transform_solutions(res::Result, f::String; branches = 1:branch_count(res), rules=Dict(), target_type=ComplexF64)
     # a string is used as input - a macro would not "see" the user's namespace while the user's namespace does not "see" the variables
-    transformed = [Vector{ComplexF64}(undef, length(res.solutions[1])) for k in res.solutions] # preallocate
+    transformed = [Vector{target_type}(undef, length(branches)) for k in res.solutions] # preallocate
 
-    # define variables in rules in this namespace
-    new_keys = declare_variable.(string.(keys(Dict(rules))))
-    expr = f isa String ? _parse_expression(f) : f
-
-    fixed_subs = merge(res.fixed_parameters, Dict(zip(new_keys, values(Dict(rules)))))
-    expr = substitute_all(expr, Dict(fixed_subs))
-
-    vars = res.problem.variables
-    all_symbols = cat(vars, collect(keys(res.swept_parameters)), dims=1)
-    comp_func = build_function(expr, all_symbols)
-    f = eval(comp_func)
+    func = _build_substituted(res, f; rules=rules)
 
     # preallocate an array for the numerical values, rewrite parts of it
     # when looping through the solutions
-    vals = Vector{ComplexF64}(undef, length(all_symbols))
-    n_vars = length(vars)
-    n_pars = length(all_symbols) - n_vars
+    n_vars = length(get_variables(res))
+    n_pars = length(res.swept_parameters)
+    vals = Vector{ComplexF64}(undef, n_vars + n_pars)
 
     for idx in CartesianIndices(res.solutions)
         params_values = res.swept_parameters[Tuple(idx)...]
         vals[end-n_pars+1:end] .= params_values # param values are common to all branches
-        for (branch,soln) in enumerate(res.solutions[idx])
-            vals[1:n_vars] .= soln
-            transformed[idx][branch] = Base.invokelatest(f, vals)
+        for (k, branch) in enumerate(branches)  
+            vals[1:n_vars] .= res.solutions[idx][branch]
+            transformed[idx][k] = Base.invokelatest(func, vals)
         end
     end
     return transformed
@@ -47,7 +37,7 @@ end
 transform_solutions(res::Result, fs::Vector{String}; kwargs...) = [transform_solutions(res, f; kwargs...) for f in fs]
 
 # a simplified version meant to work with arrays of solutions
-# cannot parse parameter values  mainly meant for time-dependent results
+# cannot parse parameter values -- meant for time-dependent results
 function transform_solutions(soln::Vector, f::String, harm_eq::HarmonicEquation)
 
     vars = _remove_brackets(get_variables(harm_eq))
@@ -61,3 +51,29 @@ function transform_solutions(soln::Vector, f::String, harm_eq::HarmonicEquation)
     transformed = map( x -> substitute_all(expr, rule(x)), soln)
     return convert(typeof(soln[1]), transformed)
 end
+
+
+""" Parse `expr` into a Symbolics.jl expression, substitute with `rules` and build a function taking free_symbols """
+function _build_substituted(expr::String, rules, free_symbols)
+
+    subbed = substitute_all(_parse_expression(expr), rules)
+    comp_func = build_function(subbed, free_symbols)
+    
+    return eval(comp_func)
+end
+
+""" Parse `expr` into a Symbolics.jl expression, substituting the fixed parameters of `res`
+The resulting function takes in the values of the variables and swept parameters. """
+function _build_substituted(res::Result, expr; rules=Dict())
+
+   # define variables in rules in this namespace
+   new_keys = declare_variable.(string.(keys(Dict(rules))))
+   fixed_subs = merge(res.fixed_parameters, Dict(zip(new_keys, values(Dict(rules)))))
+
+   free_symbols = vcat(res.problem.variables, collect(keys(res.swept_parameters)))
+   return _build_substituted(expr, fixed_subs, free_symbols)
+
+end
+
+
+## move masks here

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,7 +1,6 @@
 using Symbolics
 using OrderedCollections
 import HomotopyContinuation
-import Base.convert; export convert
 
 export DifferentialEquation, HarmonicVariable, HarmonicEquation,Problem, Result
 
@@ -11,12 +10,7 @@ const StateDict = OrderedDict{Num, ComplexF64}; export StateDict
 const SteadyState = Vector{ComplexF64}; export SteadyState;
 const ParameterVector = Vector{Float64}; export ParameterVector;
 
-
-
-import Base.getindex
-export getindex
-export +
-function getindex(p::ParameterRange, idx::Int...)
+function Base.getindex(p::ParameterRange, idx::Int...)
    lengths = [length(a) for a in values(p)]
    indices = CartesianIndices(Tuple(lengths))[idx...]
    return [val[indices[j]] for (j,val) in enumerate(values(p))]
@@ -241,6 +235,8 @@ end
 
 
 # overload to use [] for indexing
-function getindex(r::Result, idx::Int...)
-    return get_single_solution(r, idx)
-end
+Base.getindex(r::Result, idx::Int...) = get_single_solution(r, idx)
+Base.size(r::Result) = size(r.solutions)
+
+branch_count(r::Result) = length(r.solutions[1])
+get_branch(r::Result, idx) = getindex.(r.solutions, idx)

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -1,0 +1,28 @@
+using HarmonicBalance, Plots
+default(show=false)
+using Test
+
+@variables γ, λ, x, η, α, ω0, ω
+@variables t x(t)
+
+natural_equation = d(d(x,t),t) + γ*d(x,t) + ω0^2*(1-λ*cos(2*ω*t))*x + α*x^3 + η*d(x,t)*x^2
+dEOM = DifferentialEquation(natural_equation, x)
+add_harmonic!(dEOM, x, ω)
+harmonic_eq = get_harmonic_equations(dEOM);
+
+fixed = (ω0 => 1.0, γ => 1e-2, λ => 5e-2, α => 1.0, η => 0.3)
+varied = ω => range(0.9, 1.1, 100)
+res = get_steady_states(harmonic_eq, varied, fixed)
+
+# plot 1D result
+plot(res, x="ω", y="u1");
+plot_spaghetti(res, x="v1", y="u1", z="ω");
+
+fixed = (ω0 => 1.0, γ => 1e-2, α => 1.0, η => 0.3)
+varied = (ω => range(0.9, 1.1, 10), λ => range(0.01, 0.05, 10))
+res = get_steady_states(harmonic_eq, varied, fixed)
+
+# plot 2D result
+plot_phase_diagram(res);
+plot(res, "√(u1^2+v1^2)", branch = 1);
+plot(res, y = "√(u1^2+v1^2)", cut = λ => 0.03);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ files = [
     "fourier.jl",
     "load.jl",
     "parametron.jl",
+    "plotting.jl",
     "time_evolution.jl"
     ]
 


### PR DESCRIPTION
`align_pair` is supposed to sort a solution so that its branches matches that of a reference solution. In 2D, there is more than one reference.

Previously, the 2D sorting was erroneously used for the 1D loop resulting in some extra allocations. Now sorting is ~2 times faster in 1D.

![2022-11-22_20-37](https://user-images.githubusercontent.com/58295890/203406659-054e00a0-dc02-45ab-8973-a987bd01d4df.png)

