### PR TITLE
Jacobian spectrum in the rotating frame

### DIFF
--- a/src/modules/LinearResponse/plotting.jl
+++ b/src/modules/LinearResponse/plotting.jl
@@ -45,11 +45,15 @@ function get_linear_response(res::Result, nat_var::Num, Ω_range, branch::Int; o
     C
 end
 
-function get_rotframe_jacobian_response(res::Result, Ω_range, branch::Int; damping_mod::Float64)
+function get_rotframe_jacobian_response(res::Result, Ω_range, branch::Int; show_progress=show_progress, damping_mod::Float64)
     stable = classify_branch(res, branch, "stable")
     !any(stable) && error("Cannot generate a spectrum - no stable solutions!")
     stableidx = findall(stable)
     C = zeros(length(Ω_range), sum(stable));
+
+    if show_progress
+        bar = Progress(length(C), 1, "Solving the linear response ODE for each solution and input frequency ... ", 50)
+    end
 
     for i in 1:sum(stable)
         s = get_single_solution(res, branch = branch , index = stableidx[i]);
@@ -60,6 +64,7 @@ function get_rotframe_jacobian_response(res::Result, Ω_range, branch::Int; damp
                 C[k,i] += 1/sqrt((imag(j)^2-Ω_range[k]^2)^2+Ω_range[k]^2*damping_mod^2*real(j)^2)
             end
         end
+        show_progress ? next!(bar) : nothing
         
     end
     C
@@ -90,7 +95,17 @@ heatmap(X, Ω_range,  C; color=:viridis,
     xlabel=latexify(string(first(keys(res.swept_parameters)))), ylabel=latexify("Ω"), HarmonicBalance._set_Plots_default..., kwargs...)
 end
 
-function plot_rotframe_jacobian_response(res::Result; Ω_range, branch::Int, logscale=true, damping_mod::Float64 = 1.0, kwargs...)
+"""
+    plot_rotframe_jacobian_response(res::Result; Ω_range, branch::Int, logscale=true, damping_mod::Float64 = 1.0, show_progress=true, kwargs...)
+
+Plot the linear response to white noise in the rotating frame for Result `res` on `branch` for input frequencies `Ω_range`. 'damping_mod' gets multiplied by the real part of the eigenvalues of the Jacobian in order to be able to make peaks with similar frequency seperately identifiable.
+
+Any kwargs are fed to Plots' gr().
+
+Solutions not belonging to the `physical` class are ignored.
+"""
+
+function plot_rotframe_jacobian_response(res::Result; Ω_range, branch::Int, logscale=true, damping_mod::Float64 = 1.0, show_progress=true, kwargs...)
 
     length(size(res.solutions)) != 1 && error("1D plots of not-1D datasets are usually a bad idea.")
     stable = classify_branch(res, branch, "stable") # boolean array
@@ -100,7 +115,7 @@ function plot_rotframe_jacobian_response(res::Result; Ω_range, branch::Int, log
 
     X = Vector{Float64}(collect(values(res.swept_parameters))[1][stable])
     
-    C = get_rotframe_jacobian_response(res, Ω_range, branch, damping_mod=damping_mod)
+    C = get_rotframe_jacobian_response(res, Ω_range, branch, show_progress=show_progress, damping_mod=damping_mod)
     C = logscale ? log.(C) : C
     
     heatmap(X, Ω_range,  C; color=:viridis,

--- a/src/modules/LinearResponse/plotting.jl
+++ b/src/modules/LinearResponse/plotting.jl
@@ -50,11 +50,9 @@ function get_rotframe_jacobian_response(res::Result, Ω_range, branch::Int; damp
     !any(stable) && error("Cannot generate a spectrum - no stable solutions!")
     stableidx = findall(stable)
     C = zeros(length(Ω_range), sum(stable));
-    print(sum(stable))
+
     for i in 1:sum(stable)
         s = get_single_solution(res, branch = branch , index = stableidx[i]);
-        print(i)
-        print("/n")
         jac  = res.jacobian(s) #numerical Jacobian
         λs, vs = eigen(jac)
         for j in λs
@@ -92,7 +90,7 @@ heatmap(X, Ω_range,  C; color=:viridis,
     xlabel=latexify(string(first(keys(res.swept_parameters)))), ylabel=latexify("Ω"), HarmonicBalance._set_Plots_default..., kwargs...)
 end
 
-function plot_rotframe_jacobian_response(res::Result, Ω_range, branch::Int; logscale=true, damping_mod::Float64 = 1.0, kwargs...)
+function plot_rotframe_jacobian_response(res::Result; Ω_range, branch::Int, logscale=true, damping_mod::Float64 = 1.0, kwargs...)
 
     length(size(res.solutions)) != 1 && error("1D plots of not-1D datasets are usually a bad idea.")
     stable = classify_branch(res, branch, "stable") # boolean array

--- a/test/linear_response.jl
+++ b/test/linear_response.jl
@@ -1,0 +1,17 @@
+using HarmonicBalance
+import HarmonicBalance.LinearResponse.plot_linear_response
+import HarmonicBalance.LinearResponse.plot_rotframe_jacobian_response
+
+@variables α, ω, ω0, F, γ, t, x(t);
+
+diff_eq = DifferentialEquation(d(x,t,2) + ω0*x + α*x^3 + γ*d(x,t) ~ F*cos(ω*t), x)
+add_harmonic!(diff_eq, x, ω) 
+harmonic_eq = get_harmonic_equations(diff_eq)
+
+fixed = (α => 1, ω0 => 1.0, γ => 1E-2, F => 1E-6)
+varied = ω => LinRange(0.9, 1.1, 100)           
+result = get_steady_states(harmonic_eq, varied, fixed)
+
+plot_linear_response(result, x, branch=1, 
+    Ω_range=LinRange(0.9,1.1,300), order=1, logscale=true)
+plot_rotframe_jacobian_response(result, Ω_range = LinRange(0.01,1,300), branch = 1 , logscale = true)


### PR DESCRIPTION
Added a function to the linear_response module to calculate and plot the fluctuation spectrum of the Jacobian in the rotating frame (plot_rotframe_jacobian_response and get_rotframe_jacobian_response).
The function is really similar to plot_linear_response in first order. An additional factor damping_mod was added to ease inspection of fluctuation spectra where two peaks are really close to each other.

Otherwise a short test for the linear_response module that plots the fluctuation spectrum of a quasi-linear oscillator in the rotating and lab frame was added.