### PR TITLE
single-argument input for parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ add_harmonic!(diff_eq, x, ω) # specify the ansatz x = u(T) cos(ωt) + v(T) sin(
 # implement ansatz to get harmonic equations
 harmonic_eq = get_harmonic_equations(diff_eq)
 
-fixed = (α => 1., ω0 => 1.0, F => 0.01, η=>0.1)   # fixed parameters
-varied = ω => LinRange(0.9, 1.2, 100)           # range of parameter values
-result = get_steady_states(harmonic_eq, varied, fixed)
+# solve for a range of ω
+result = get_steady_states(harmonic_eq, (ω => LinRange(0.9, 1.2, 100),
+                                          α => 1., ω0 => 1.0, F => 0.01, η=>0.1))
 ```
 ```
 A steady state result for 100 parameter points

--- a/src/solve_homotopy.jl
+++ b/src/solve_homotopy.jl
@@ -129,7 +129,7 @@ end
 
 get_steady_states(p::Problem, swept, fixed; kwargs...) = get_steady_states(p, ParameterRange(swept), ParameterList(fixed); kwargs...)
 get_steady_states(eom::HarmonicEquation, swept, fixed; kwargs...) = get_steady_states(Problem(eom), swept, fixed; kwargs...)
-get_steady_states(p::Union{Problem, HarmonicEquation}, fixed; kwargs...) = get_steady_states(p, [], fixed; kwargs...)
+get_steady_states(p, pairs; kwargs...) = get_steady_states(p, filter( x->length(x[2]) > 1, pairs), filter(x -> length(x[2]) == 1, pairs); kwargs...)
 
 
 """ Compile the Jacobian from `prob`, inserting `fixed_parameters`.


### PR DESCRIPTION
Playing with `HarmonicBalance` after a while, the enforced arbitrary order of parameters to `get_steady_states` is annoying. This unpacks an array of fixed/varied parameters automatically.

Example of now-valid input:
`get_steady_states(harmonic_eq, (ω => LinRange(0.9, 1.2, 100),
                                          α => 1., ω0 => 1.0, F => 0.01, η=>0.1))`