### PR TITLE
enable threading by default

### DIFF
--- a/src/solve_homotopy.jl
+++ b/src/solve_homotopy.jl
@@ -35,7 +35,7 @@ get_single_solution(res::Result, index) = [get_single_solution(res, index=index,
                         swept_parameters::ParameterRange,
                         fixed_parameters::ParameterList;
                         random_warmup=true,
-                        threading=false,
+                        threading = Threads.nthreads() > 1,
                         show_progress=true,
                         sorting="nearest")
 
@@ -86,7 +86,7 @@ A steady state result for 1000 parameter points
 ```
 
 """
-function get_steady_states(prob::Problem, swept_parameters::ParameterRange, fixed_parameters::ParameterList; random_warmup=true, threading=false, show_progress=true, sorting="nearest", classify_default=true)
+function get_steady_states(prob::Problem, swept_parameters::ParameterRange, fixed_parameters::ParameterList; random_warmup=true, threading = Threads.nthreads() > 1, show_progress=true, sorting="nearest", classify_default=true)
     # make sure the variables are in our namespace to make them accessible later
     declare_variable.(string.(cat(prob.parameters, prob.variables, dims=1)))
 


### PR DESCRIPTION
enable threading by default when Julia is started with multiple threads.