### PR TITLE
Make it possible to thread the classification of solutions

### DIFF
--- a/src/classification.jl
+++ b/src/classification.jl
@@ -49,7 +49,7 @@ end
 according to `f` (`f` takes a solution dictionary, return a boolean)"
 function classify_solutions(res::Result, f::Function)
     values = similar(res.solutions, BitVector)
-    for (idx, soln) in enumerate(res.solutions)
+    @maybethread for (idx, soln) in enumerate(res.solutions)
         values[idx] = [f(get_single_solution(res, index=idx, branch=b), res) for b in 1:length(soln)]
     end
     values
@@ -144,4 +144,3 @@ function filter_result!(res::Result, class::String)
         res.classes[c] = [s[bools] for s in res.classes[c]]
     end
 end
-

--- a/src/classification.jl
+++ b/src/classification.jl
@@ -49,7 +49,7 @@ end
 according to `f` (`f` takes a solution dictionary, return a boolean)"
 function classify_solutions(res::Result, f::Function)
     values = similar(res.solutions, BitVector)
-    @maybethread for (idx, soln) in enumerate(res.solutions)
+    @maybethread for (idx, soln) in collect(enumerate(res.solutions))
         values[idx] = [f(get_single_solution(res, index=idx, branch=b), res) for b in 1:length(soln)]
     end
     values


### PR DESCRIPTION
When classifying the solutions of 4 parametrons (81 stable branches), it takes one hour to complete on one thread. Instead, now the loop inside the classification function will be threaded to speed up the process.

Resolves #86 