### PR TITLE
Play with warmup method and add polyhedral method

### DIFF
--- a/src/solve_homotopy.jl
+++ b/src/solve_homotopy.jl
@@ -250,7 +250,7 @@ end
 "A random warmup solution is computed to use as `start_parameters` in the homotopy."
 function _solve_warmup(problem::Problem, params_1D, sweep; threading, show_progress)
     # complex perturbation of the warmup parameters
-    complex_pert = [1e-5 * issubset(p, keys(sweep))* randn(ComplexF64) for p in problem.parameters]
+    complex_pert = [1e-5 * randn(ComplexF64) for p in problem.parameters]
     real_pert = ones(length(params_1D[1]))
     warmup_parameters = params_1D[end÷2] .* (real_pert + complex_pert)
 

--- a/src/solve_homotopy.jl
+++ b/src/solve_homotopy.jl
@@ -276,7 +276,7 @@ function _get_raw_solution(problem::Problem, parameter_values;
                 start_parameters=warmup_parameters, target_parameters=parameter_values,
                 threading=threading, show_progress=show_progress, seed=seed
             )
-    elseif method==:total_degree
+    elseif method==:total_degree || method==:polyhedral
         result_full = Array{Vector{Any}, 1}(undef, length(parameter_values))
         if show_progress
             bar = Progress(length(parameter_values), 1, "Solving via total degree homotopy ...", 50)

--- a/src/solve_homotopy.jl
+++ b/src/solve_homotopy.jl
@@ -93,7 +93,7 @@ A steady state result for 1000 parameter points
 """
 function get_steady_states(prob::Problem, swept_parameters::ParameterRange, fixed_parameters::ParameterList;
     method=:warmup, threading = Threads.nthreads() > 1, show_progress=true,
-    sorting="nearest", classify_default=true, seed=nothing)
+    sorting="nearest", classify_default=true, seed=nothing, kwargs...)
 
     # set seed if provided
     !isnothing(seed) && Random.seed!(seed)
@@ -108,8 +108,9 @@ function get_steady_states(prob::Problem, swept_parameters::ParameterRange, fixe
 
     input_array = _prepare_input_params(prob, swept_parameters, unique_fixed)
     # feed the array into HomotopyContinuation, get back an similar array of solutions
-    raw = _get_raw_solution(prob, input_array;
-    sweep=swept_parameters, method=method, threading=threading, show_progress=show_progress, seed=seed)
+    raw = _get_raw_solution(
+        prob, input_array; sweep=swept_parameters, method=method, threading=threading,
+        show_progress=show_progress, seed=seed, kwargs...)
 
     # extract all the information we need from results
     #rounded_solutions = unique_points.(HomotopyContinuation.solutions.(getindex.(raw, 1)); metric = EuclideanNorm(), atol=1E-14, rtol=1E-8)
@@ -262,7 +263,7 @@ end
 
 "Uses HomotopyContinuation to solve `problem` at specified `parameter_values`."
 function _get_raw_solution(problem::Problem, parameter_values;
-    sweep=ParameterRange(), method=:warmup, threading=false, show_progress=true, seed=nothing)
+    sweep=ParameterRange(), method=:warmup, threading=false, show_progress=true, seed=nothing, kwargs...)
     # HomotopyContinuation accepts 1D arrays of parameter sets
     params_1D = reshape(parameter_values, :, 1)
 
@@ -274,12 +275,12 @@ function _get_raw_solution(problem::Problem, parameter_values;
             HC.solve(
                 problem.system, HC.solutions(warmup_solution);
                 start_parameters=warmup_parameters, target_parameters=parameter_values,
-                threading=threading, show_progress=show_progress, seed=seed
+                threading=threading, show_progress=show_progress, seed=seed, kwargs...
             )
     elseif method==:total_degree || method==:polyhedral
         result_full = Array{Vector{Any}, 1}(undef, length(parameter_values))
         if show_progress
-            bar = Progress(length(parameter_values), 1, "Solving via total degree homotopy ...", 50)
+            bar = Progress(length(parameter_values), 1, "Solving via $method homotopy ...", 50)
         end
         for i in eachindex(parameter_values) # do NOT thread this
             p = parameter_values[i]

--- a/src/solve_homotopy.jl
+++ b/src/solve_homotopy.jl
@@ -249,12 +249,12 @@ end
 "A random warmup solution is computed to use as `start_parameters` in the homotopy."
 function _solve_warmup(problem::Problem, params_1D, sweep; threading, show_progress)
     # complex perturbation of the warmup parameters
-    complex_pert = [1e-2 * issubset(p, keys(sweep)) * randn(ComplexF64) for p in problem.parameters]
+    complex_pert = [1e-5 * issubset(p, keys(sweep))* randn(ComplexF64) for p in problem.parameters]
     real_pert = ones(length(params_1D[1]))
     warmup_parameters = params_1D[end÷2] .* (real_pert + complex_pert)
 
     warmup_solution =
-        HC.solve(problem.system;
+        HC.solve(problem.system; start_system=:total_degree,
         target_parameters=warmup_parameters, threading=threading, show_progress=show_progress
         )
     return warmup_parameters, warmup_solution
@@ -285,7 +285,7 @@ function _get_raw_solution(problem::Problem, parameter_values;
             p = parameter_values[i]
             show_progress ? next!(bar) : nothing
             result_full[i] = [
-                HC.solve(problem.system; start_system=:total_degree,
+                HC.solve(problem.system; start_system=method,
                 target_parameters=p, threading=threading, show_progress=false, seed=seed), p]
         end
     else


### PR DESCRIPTION
The warmup method sometimes does not find a root. Notably for the parametron this is always the zero solution. The reason that this happens is because [we can't track the solution through the discriminant](https://github.com/JuliaHomotopyContinuation/HomotopyContinuation.jl/issues/492). I have been playing around with warmup parameters to make the change of not finding the root smaller.
```julia
using HarmonicBalance, ProgressMeter, Random; 
mean(v) = sum(v)/length(v)

@variables t x(t) # symbolic variables
@variables ω ω0 γ λ α η
natural_equation = d(d(x, t), t) + γ*d(x, t) + ω0^2*(1-λ*cos(2*ω*t))*x + α*x^3 + η*d(x, t)*x^2
diff_eq = DifferentialEquation(natural_equation, x)

add_harmonic!(diff_eq, x, ω);
harmonic_eq = get_harmonic_equations(diff_eq);

varied  = (ω => range(0.99, 1.01, 50), λ => range(1e-6, 0.03, 50))
fixed  = Dict(ω0 => 1.0, γ => 0.005, α => 1.0, η => 0.3)

SEED = rand(UInt32)
Random.seed!(SEED)
result  = get_steady_states(harmonic_eq, varied, fixed, seed=SEED, show_progress=false, threading=true);

plot_phase_diagram(result , class= "stable", clim=(0,3))

l = 100
v = zeros(l)
@showprogress dt=1 desc="Computing..." for idx in 1:l
    SEED = rand(UInt32)
    Random.seed!(SEED)
    result  = get_steady_states(harmonic_eq, varied, fixed, seed=SEED, show_progress=false, threading=true);
    v[idx] = findfirst(v -> all(.!v), result.classes["stable"]) |> isnothing
end
mean(v)
```
![image](https://github.com/NonlinearOscillations/HarmonicBalance.jl/assets/57623933/2c74fa7f-e54b-40a2-9e4f-be921197b850)

This should be merger after #136, #137 and #139