### PR TITLE
Optimise sorting

### DIFF
--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -80,19 +80,19 @@ function align_pair(reference, to_sort::Vector{SteadyState})
 
     distances = get_distance_matrix(reference, to_sort)
     n = length(to_sort)
+    sorted_cartesians = CartesianIndices(distances)[sortperm(vec(distances))]
 
-    matched = Set{Int}()
-    matched_ref = Set{Int}()
+    matched = falses(n)
+    matched_ref = falses(n)
 
     sorted = Vector{CartesianIndex}(undef, n)
 
-    for j in 1:n
-        # Find the index of the minimum distance that hasn't been matched yet
-        min_k = argmin([distances[j, k] for k in 1:n if !(k in matched)])
-        if !(j in matched_ref)
-            push!(matched, min_k)
-            push!(matched_ref, j)
-            sorted[j] = CartesianIndex(j, min_k)
+    for idx in sorted_cartesians
+        j,k = idx[1], idx[2]
+        if !matched[k] && !matched_ref[j]
+            matched[k] = true
+            matched_ref[j] = true
+            sorted[j] = idx
         end
     end
 

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -80,19 +80,19 @@ function align_pair(reference, to_sort::Vector{SteadyState})
 
     distances = get_distance_matrix(reference, to_sort)
     n = length(to_sort)
-    sorted_cartesians = CartesianIndices(distances)[sortperm(vec(distances))]
 
-    matched = falses(n)
-    matched_ref = falses(n)
+    matched = Set{Int}()
+    matched_ref = Set{Int}()
 
     sorted = Vector{CartesianIndex}(undef, n)
 
-    for idx in sorted_cartesians
-        j,k = idx[1], idx[2]
-        if !matched[k] && !matched_ref[j]
-            matched[k] = true
-            matched_ref[j] = true
-            sorted[j] = idx
+    for j in 1:n
+        # Find the index of the minimum distance that hasn't been matched yet
+        min_k = argmin([distances[j, k] for k in 1:n if !(k in matched)])
+        if !(j in matched_ref)
+            push!(matched, min_k)
+            push!(matched_ref, j)
+            sorted[j] = CartesianIndex(j, min_k)
         end
     end
 

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -80,7 +80,7 @@ function align_pair(reference, to_sort::Vector{SteadyState})
 
     distances = get_distance_matrix(reference, to_sort)
     n = length(to_sort)
-    sorted_cartesians = CartesianIndices(distances)[sortperm(vec(distances))]
+    sorted_cartesians = CartesianIndices(distances)[sortperm(distances, dims=1)] #julia 1.9
 
     matched = falses(n)
     matched_ref = falses(n)


### PR DESCRIPTION
The `align_pair` function in the sorting.jl file can be optimized in the following ways:
* Avoid unnecessary computations: You're computing the sortperm of the entire distances matrix, which is an O(n^2) operation. However, you only need the minimum distance for each reference, which can be found in O(n) time.

* Use efficient data structures: You're using arrays to keep track of which elements have been matched. Consider using a Set for this, which has O(1) lookup time.

From 
![image](https://github.com/NonlinearOscillations/HarmonicBalance.jl/assets/57623933/131298ca-11d6-4aa0-bb59-d835aecad8fd)
to
![image](https://github.com/NonlinearOscillations/HarmonicBalance.jl/assets/57623933/352673e3-83cd-4040-9db0-4a953cb4bf74)
