### PR TITLE
docs: add second order in linear response tutrial

### DIFF
--- a/benchmark/parametron.jl
+++ b/benchmark/parametron.jl
@@ -1,4 +1,5 @@
-using HarmonicBalance
+using HarmonicBalance, Plots
+using BenchmarkTools
 using HomotopyContinuation
 
 @variables ω₀ γ λ α ω t x(t)
@@ -9,7 +10,7 @@ diff_eq = DifferentialEquation(natural_equation, x)
 add_harmonic!(diff_eq, x, ω);
 
 harmonic_eq = get_harmonic_equations(diff_eq)
-prob = HarmonicBalance.Problem(harmonic_eq)
+# harmonic_eq = HarmonicBalance.harmonic_eqlem(harmonic_eq)
 
 fixed = (ω₀ => 1.0, γ => 0.002, α => 1.0)
 varied = (ω => range(0.99, 1.01, 100), λ => range(1e-6, 0.03, 100))
@@ -22,7 +23,7 @@ track_options = HomotopyContinuation.TrackerOptions(;
 )
 end_options = HomotopyContinuation.EndgameOptions(; refine_steps=10)
 method = WarmUp(; compile=true, tracker_options=track_options, endgame_options=end_options)
-result_2D = get_steady_states(prob, method, varied, fixed; show_progress=false)
+result_2D = get_steady_states(harmonic_eq, method, varied, fixed; show_progress=false)
 plot_phase_diagram(result_2D; class="stable")
 
 # loose some solutions
@@ -33,28 +34,28 @@ end_options = HomotopyContinuation.EndgameOptions(;
     endgame_start=0.0, only_nonsingular=true
 )
 method = WarmUp(; compile=true, tracker_options=track_options, endgame_options=end_options)
-result_2D = get_steady_states(prob, method, varied, fixed; show_progress=false)
+result_2D = get_steady_states(harmonic_eq, method, varied, fixed; show_progress=false)
 plot_phase_diagram(result_2D; class="stable")
 
-@btime $get_steady_states($prob, $WarmUp(), $varied, $fixed; show_progress=false)
+@btime $get_steady_states($harmonic_eq, $WarmUp(), $varied, $fixed; show_progress=false)
 # 1.029 s (4495544 allocations: 445.47 MiB)
 
 @btime $get_steady_states(
-    $prob, $WarmUp(; compile=true), $varied, $fixed; show_progress=false
+    $harmonic_eq, $WarmUp(; compile=true), $varied, $fixed; show_progress=false
 ) # 953.323 ms (4490408 allocations: 442.09 MiB)
 
 track_options = HomotopyContinuation.TrackerOptions(; parameters=:fast)
 method = WarmUp(; compile=true, tracker_options=track_options)
-@btime $get_steady_states($prob, $method, $varied, $fixed; show_progress=false) #  747.007 ms (4460916 allocations: 438.87 MiB)
+@btime $get_steady_states($harmonic_eq, $method, $varied, $fixed; show_progress=false) #  747.007 ms (4460916 allocations: 438.87 MiB)
 
 track_options = HomotopyContinuation.TrackerOptions(; parameters=:fast)
 end_options = HomotopyContinuation.EndgameOptions(; endgame_start=0.0)
 method = WarmUp(; compile=true, tracker_options=track_options, endgame_options=end_options)
-@btime $get_steady_states($prob, $method, $varied, $fixed; show_progress=false) # 734.310 ms (4460118 allocations: 438.81 MiB)
+@btime $get_steady_states($harmonic_eq, $method, $varied, $fixed; show_progress=false) # 734.310 ms (4460118 allocations: 438.81 MiB)
 
 track_options = HomotopyContinuation.TrackerOptions(;
     parameters=:fast, extended_precision=false
 )
 end_options = HomotopyContinuation.EndgameOptions(; endgame_start=0.0)
 method = WarmUp(; compile=true, tracker_options=track_options, endgame_options=end_options)
-@btime $get_steady_states($prob, $method, $varied, $fixed; show_progress=false) # 734.310 ms (4460118 allocations: 438.81 MiB)
+@btime $get_steady_states($harmonic_eq, $method, $varied, $fixed; show_progress=false) # 734.310 ms (4460118 allocations: 438.81 MiB)

--- a/docs/src/tutorials/linear_response.md
+++ b/docs/src/tutorials/linear_response.md
@@ -60,7 +60,11 @@ plot_linear_response(result, x, 1, Ω_range=range(0.95, 1.05, 300), logscale=tru
 
 The response has a peak at $\omega_0$, irrespective of the driving frequency $\omega$. Indeed, the eigenvalues shown before where plotted in the rotating frame at the frequency of the drive $\omega$. Hence, the imaginary part of eigenvalues shows the frequency (energy) needed to excite the system at it natural frequency (The frequency its want to be excited at.)
 
-Note the slight "bending" of the noise peak with $\omega$ - this is given by the failure of the first-order calculation to capture response far-detuned from the drive frequency.
+Note the slight "bending" of the noise peak with $\omega$ - this is given by the failure of the first-order calculation of the jacobian to capture response far-detuned from the drive frequency. One can correct this by using higher-order derivatives of the `Differentialequation` object in the jacobian calculation. For more details on this see the [thesis](https://www.doi.org/10.3929/ethz-b-000589190). We can use this corrections by setting the `order` argument in the `plot_linear_response` function:
+
+```@example linresp
+plot_linear_response(result, x, 1, Ω_range=range(0.95, 1.05, 300), logscale=true, order=2)
+```
 
 To compute the matrix without plotting you can use the functions specified at the [linear respinse manual](@ref linresp_man).
 


### PR DESCRIPTION
## Checklist

Thank you for contributing to `HarmonicBalance.jl`! Please make sure you have finished the following tasks before finishing the PR.

<!-- - [ ] Any code changes were done in a way that does not break public API. -->
- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
<!-- - [ ] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`. -->

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description

Describe the proposed change here.

## Related issues or PRs

resolve #253 

## Additional context
