### PR TITLE
build: restore Julia 1.10 LTS support

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.12'
+          version: '1'
           arch: x64
       - uses: julia-actions/cache@v3
       - name: Run benchmark

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.12'
+          version: 'lts'
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -29,7 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.12'
+          - 'lts'
+          - '1'
         os:
           - ubuntu-latest
         arch:
@@ -59,4 +60,4 @@ jobs:
           files: lcov.info
           name: codecov-umbrella
           fail_ci_if_error: false
-        if: ${{ matrix.version == '1.12' }}
+        if: ${{ matrix.version == 'lts' }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HarmonicBalance"
 uuid = "e13b9ff6-59c3-11ec-14b1-f3d2cc6c135e"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Orjan Ameye <orjan.ameye@hotmail.com>", "Jan Kosata <kosataj@phys.ethz.ch>", "Javier del Pino <jdelpino@phys.ethz.ch>"]
 
 [deps]
@@ -33,7 +33,7 @@ Reexport = "1.2.2"
 SymbolicUtils = "4"
 Symbolics = "7"
 Test = "1.10"
-julia = "1.12"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -27,6 +27,6 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 Documenter = "1"
-julia = "1.12"
+julia = "1.10"
 HarmonicSteadyState = "0.5"
 QuestBase = "0.4.1"

--- a/ext/ModelingToolkitBaseExt.jl
+++ b/ext/ModelingToolkitBaseExt.jl
@@ -10,7 +10,8 @@ using QuestBase:
 using HarmonicBalance:
     HarmonicEquation, get_variables, DifferentialEquation, get_independent_variables
 using HarmonicBalance: first_order_transform!
-using Symbolics: simplify, Equation, substitute, Num, expand, unwrap, arguments, wrap
+using Symbolics: simplify, Equation, substitute, Num, expand, arguments, wrap
+using SymbolicUtils: unwrap
 using ModelingToolkitBase:
     ModelingToolkitBase,
     System,

--- a/src/HarmonicBalance.jl
+++ b/src/HarmonicBalance.jl
@@ -40,11 +40,10 @@ using Symbolics:
     expand_derivatives,
     get_variables,
     Differential,
-    unwrap,
     diff2term,
     lower_varname
 
-using SymbolicUtils: SymbolicUtils, BasicSymbolic, isdiv
+using SymbolicUtils: SymbolicUtils, BasicSymbolic, isdiv, unwrap
 
 # src code
 include("DifferentialEquation.jl")


### PR DESCRIPTION
Lowers `julia` compat back to `"1.10"` (also in `docs/Project.toml`) and bumps the version to 0.17.1. Restores `lts` in the `Tests.yml` matrix (`['lts', '1']`, with coverage uploaded from the lts job) and in `Documentation.yml`, and puts the benchmark job back on `'1'`, matching the configuration before the Symbolics 7 migration.

Also imports `unwrap` from its owner `SymbolicUtils` rather than from `Symbolics`. `Base.which` resolves the owner differently on 1.10, so `check_all_explicit_imports_via_owners` fails there otherwise.

Depends on HarmonicSteadyState 0.5.2 and QuestBase 0.4.2, both registered and propagated, which are the first releases of those packages to support 1.10 again.

Verified locally on 1.10.11: `JET.report_package(HarmonicBalance)` reports no errors and `check_no_stale_explicit_imports` passes. Worth noting that `test/code_quality.jl` gates the JET testset on `VERSION < v\"1.12.0-beta\"`, so restoring `lts` re-enables JET, which has not run in CI since the matrix went 1.12-only.