### PR TITLE
fix: read the source system through QuestBase.source

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HarmonicBalance"
 uuid = "e13b9ff6-59c3-11ec-14b1-f3d2cc6c135e"
-version = "0.17.1"
+version = "0.18.0"
 authors = ["Orjan Ameye <orjan.ameye@hotmail.com>", "Jan Kosata <kosataj@phys.ethz.ch>", "Javier del Pino <jdelpino@phys.ethz.ch>"]
 
 [deps]
@@ -22,12 +22,12 @@ Aqua = "0.8.11"
 DocStringExtensions = "0.9.4"
 Documenter = "1.4"
 ExplicitImports = "1.6"
-HarmonicSteadyState = "0.5"
+HarmonicSteadyState = "0.6"
 JET = "0.9.18, 0.10"
 ModelingToolkitBase = "1"
 OrdinaryDiffEqTsit5 = "2"
 PrecompileTools = "1.2"
-QuestBase = "0.4.1"
+QuestBase = "0.5"
 Random = "1.10"
 Reexport = "1.2.2"
 SymbolicUtils = "4"

--- a/benchmarks/Project.toml
+++ b/benchmarks/Project.toml
@@ -14,6 +14,6 @@ SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 
 [compat]
 Documenter = "1"
-HarmonicSteadyState = "0.5"
-QuestBase = "0.4.1"
+HarmonicSteadyState = "0.6"
+QuestBase = "0.5"
 julia = "1.12"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -28,5 +28,5 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 [compat]
 Documenter = "1"
 julia = "1.10"
-HarmonicSteadyState = "0.5"
-QuestBase = "0.4.1"
+HarmonicSteadyState = "0.6"
+QuestBase = "0.5"

--- a/src/HarmonicEquation.jl
+++ b/src/HarmonicEquation.jl
@@ -109,7 +109,7 @@ function fourier_transform!(eom::HarmonicEquation, time::Num)
         # find the equation belonging to this variable
         eq_idx = findfirst(
             x -> isequal(x, hvar.natural_variable),
-            collect(keys(eom.natural_equation.equations)),
+            collect(keys(QuestBase.source(eom).equations)),
         )
         eq = eom.equations[eq_idx]
         # "type" is usually "u" or "v" (harmonic) or ["a"] (zero-harmonic)


### PR DESCRIPTION
## Description

QuestBase 0.5 replaced `HarmonicEquation`'s `natural_equation::DifferentialEquation` field with `source_equations::T` on a new type parameter, so that harmonic equations are no longer assumed to come from a second order `DifferentialEquation` in the lab frame. `fourier_transform!` was the one place in this package reaching for the old field:

```julia
collect(keys(eom.natural_equation.equations))   # before
collect(keys(QuestBase.source(eom).equations))  # after
```

Everything else here already goes through the constructors rather than the fields, so no other change was needed.

Compat bounds move to the releases that carry the source accessors: `QuestBase = "0.5"` and `HarmonicSteadyState = "0.6"`.

## Related issues or PRs

Part of a coordinated change across three packages:

- QuantumEngineeredSystems/QuestBase.jl#38 adds `source` / `source_type` and reparametrises `HarmonicEquation` (merged, releasing as 0.5.0).
- QuantumEngineeredSystems/HarmonicSteadyState.jl#61 propagates the source through `HomotopyContinuationProblem` and `Result`.

This one is not optional. HarmonicBalance is in HarmonicSteadyState's test target, so its test suite cannot load until this lands.

## Additional context

Breaking, so this releases as 0.18.0. Anything reading `natural_equation` off an equation built here has to move to `QuestBase.source` too, and a patch release would have been auto-resolved by already-released versions pinned to `QuestBase = "0.4.1"`.

Tested locally against the two branches above with `[sources]` overrides: full suite green.
