### PR TITLE
fix: deploy the docs with DocumenterVitepress.deploydocs

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -33,6 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # DocumenterVitepress reads `git tag` to decide which base aliases
+          # (`stable`, `v0.18`, ...) this build owns, so it needs the full tag list.
+          fetch-depth: 0
       - uses: julia-actions/setup-julia@v3
         with:
           version: 'lts'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -83,7 +83,10 @@ makedocs(;
 )
 
 if CI
-    deploydocs(;
+    # `DocumenterVitepress.deploydocs`, not `Documenter.deploydocs`: Vitepress bakes the
+    # base URL into the site, so one build per base alias (`stable`, `v0.18`, ...) lands in
+    # `build/1`, `build/2`, ... and only this wrapper knows how to deploy each to its folder.
+    DocumenterVitepress.deploydocs(;
         repo="github.com/QuantumEngineeredSystems/HarmonicBalance.jl",
         devbranch="master",
         target="build",

--- a/docs/src/introduction/index.md
+++ b/docs/src/introduction/index.md
@@ -28,7 +28,7 @@ Let us find the steady states of an external driven Duffing oscillator with nonl
 
 ```math
 \begin{equation}
-\underbrace{\ddot{x}(t) + \gamma \dot{x}(t) + \omega_0^2 x(t)}_{\text{damped harmonic oscillator}} + \underbrace{\alpha x(t)^3}_{\text{Duffing coefficient}} = \underbrace{F \cos(\omega t)}_{\text{periodic drive}}
+\underbrace{\ddot{x}(t) + \omega_0^2 x(t)}_{\text{harmonic oscillator}} + \underbrace{\alpha x(t)^3}_{\text{Duffing coefficient}} + \underbrace{\eta x(t)^2 \dot{x}(t)}_{\text{nonlinear damping}} = \underbrace{F \cos(\omega t)}_{\text{periodic drive}}
 \end{equation}
 ```
 


### PR DESCRIPTION
Closes #472
Closes #474

Docs have been broken since v0.17.0. DocumenterVitepress 0.3 builds the site once
per base alias (Vitepress bakes the base URL in), dropping them in `build/1`,
`build/2`, ... with `build/bases.txt` naming them. Only
`DocumenterVitepress.deploydocs` knows how to unpack that, and we were calling
plain `deploydocs`, which is Documenter's and copies `build/` as is. So every
version folder since then holds `1/`, `2/` and nothing servable.

Also fetching all tags in the workflow, since `determine_bases` uses `git tag` to
work out whether a build owns the `stable` alias.

Already cleaned up `gh-pages` by hand: dropped the broken v0.17/v0.18/dev folders
and the `stable`, `v0.17`, `v0.18` symlinks that DocumenterVitepress won't deploy
over. Root redirect points at v0.16 until the next release.

Separately, the getting started equation showed linear damping while the code
under it uses the nonlinear term. Copy-paste from the Duffing tutorial, fixed the
equation.
