### PR TITLE
ci: build the docs on the latest Julia again

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -39,7 +39,9 @@ jobs:
           fetch-depth: 0
       - uses: julia-actions/setup-julia@v3
         with:
-          version: 'lts'
+          # Not 'lts': the docs build is 2.5x slower on 1.10 (96 min -> 234 min).
+          # The test matrix is what guards our 1.10 support.
+          version: '1'
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1


### PR DESCRIPTION
The docs build takes 3h20m right now. #512 switched this job from '1.12' to
'lts' and it went from 96 to 234 minutes; before the Symbolics 7 migration it
was ~60.

| master | Julia | docs build |
|---|---|---|
| pre-`ed7d013e` | 1.12 | ~60 min |
| `ed7d013e` (Symbolics 7) | 1.12 | 96 min |
| `9f449b40` (#512, lts) | 1.10 | 234 min |
| `7f9c72d1` | 1.10 | 200 min |

Almost all of it is one silent stretch inside Documenter's ExpandTemplates,
so it's the `@example` blocks, and 1.10 is much slower at them. For reference
the nine `examples/*.jl` scripts total 14 min on 12 threads, so no single
example is to blame.

Our 1.10 support is guarded by the test matrix. The docs build isn't a
compatibility surface, so it shouldn't be paying for the LTS. `julia = "1.10"`
in docs/Project.toml is a lower bound, so '1' satisfies it.
