### PR TITLE
fix: reject equations that are not polynomial in the variables

### DIFF
--- a/docs/src/manual/entering_eom.md
+++ b/docs/src/manual/entering_eom.md
@@ -13,3 +13,31 @@ add_harmonic!
 get_variables(::DifferentialEquation)
 get_independent_variables(::DifferentialEquation)
 ```
+
+## Which equations can be entered
+
+The equations have to be **polynomial in the variables** and their derivatives. Harmonic balance replaces each variable by a truncated Fourier series, and only sums, products and non-negative integer powers turn a finite Fourier series into another finite Fourier series. A term such as $\sin(x)$, $e^{x}$ or $1/x$ does not, so `get_harmonic_equations` and `get_krylov_equations` reject it:
+
+```julia
+julia> @variables α, ω0, ω, F, t, x(t);
+
+julia> diff_eq = DifferentialEquation(d(x, t, 2) + ω0^2 * x + α * sin(x) ~ F * cos(ω * t), x);
+
+julia> add_harmonic!(diff_eq, x, ω);
+
+julia> get_harmonic_equations(diff_eq)
+ERROR: ArgumentError: The term(s) sin(x(t)) are not polynomial in x(t) and cannot be averaged. [...]
+```
+
+Expand such a term in the variable first. For the pendulum above, $\sin(x) \approx x - x^3/6$ turns the equation into a Duffing oscillator, which harmonic balance handles.
+
+The time dependence of the parameters, on the other hand, must be harmonic: `cos(2ωt) * x` is fine, `cos(ω t^2) * x` and `t * x` are not.
+
+## Choosing the harmonics
+
+Only the harmonics passed to `add_harmonic!` are kept, everything else the nonlinearity generates is projected out. A nonlinear term therefore only shows up in the harmonic equations if it feeds back into a harmonic of the ansatz. With the single-harmonic ansatz $x = u \cos(\omega t) + v \sin(\omega t)$:
+
+- $x^3$ generates $\omega$ and $3\omega$; the $\omega$ part is kept, so the term contributes.
+- $x^2$, $x^4$, $x^{10}$ and every other even power generate only $0, 2\omega, 4\omega, \dots$ and contribute *nothing*. The harmonic equations are then those of the linear oscillator, which is correct for this ansatz rather than a sign that the term was ignored by mistake.
+
+To capture an even nonlinearity, add the harmonics it produces, e.g. `add_harmonic!(diff_eq, x, 2ω)` next to `add_harmonic!(diff_eq, x, ω)`. Adding harmonics enlarges the system (two equations per harmonic per variable), so add them one at a time and stop once the quantity you care about no longer changes.

--- a/src/HarmonicEquation.jl
+++ b/src/HarmonicEquation.jl
@@ -6,8 +6,7 @@ time variable. For each harmonic of each variable, instance(s) of `HarmonicVaria
 automatically created and named.
 """
 function harmonic_ansatz(diff_eom::DifferentialEquation, time::Num)
-    !is_harmonic(diff_eom, time) &&
-        error("The differential equation is not harmonic in ", time, " !")
+    assert_averageable(diff_eom, time)
     eqs = collect(values(diff_eom.equations))
     rules, vars = Dict(), []
 
@@ -201,6 +200,35 @@ function get_harmonic_equations(
 
     jacobian == true ? add_jacobian!(eom) : nothing
     return eom
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Throw if `diff_eom` cannot be averaged: every time dependence must be harmonic in `time`
+and every equation must be polynomial in the variables and their derivatives.
+
+The second condition is the one silently violated by terms such as `sin(x)` or `exp(x)`:
+the harmonic ansatz turns them into a function of `time` which is not a finite Fourier
+series, so the Fourier projection returns nothing for them and they drop out of the
+harmonic equations without a trace.
+"""
+function assert_averageable(diff_eom::DifferentialEquation, time::Num)
+    is_harmonic(diff_eom, time) ||
+        error("The differential equation is not harmonic in ", time, " !")
+
+    bad_terms = QuestBase.nonpolynomial_terms(diff_eom)
+    isempty(bad_terms) || throw(
+        ArgumentError(
+            "The term(s) $(join(bad_terms, ", ")) are not polynomial in " *
+            "$(join(get_variables(diff_eom), ", ")) and cannot be averaged. " *
+            "Harmonic balance replaces each variable by a truncated Fourier series, which " *
+            "stays a finite Fourier series only under sums, products and non-negative " *
+            "integer powers. Expand such terms in the variables first " *
+            "(e.g. sin(x) ≈ x - x^3/6) before deriving the harmonic equations.",
+        ),
+    )
+    return nothing
 end
 
 "Rearrange `eq` to have zero on the right-hand-side."

--- a/src/krylov-bogoliubov.jl
+++ b/src/krylov-bogoliubov.jl
@@ -52,6 +52,9 @@ function get_krylov_equations(
     slow_time = isnothing(slow_time) ? (@variables T; T) : slow_time
     fast_time = isnothing(fast_time) ? get_independent_variables(diff_eom)[1] : fast_time
 
+    # check before rearranging: `rearrange_standard!` can hide a variable in a denominator
+    assert_averageable(diff_eom, fast_time)
+
     dEOM = deepcopy(diff_eom)
     !is_rearranged_standard(dEOM) ? rearrange_standard!(dEOM) : nothing
     eom = van_der_Pol(dEOM, fast_time)

--- a/test/HarmonicEquation.jl
+++ b/test/HarmonicEquation.jl
@@ -1,0 +1,81 @@
+using HarmonicBalance
+using Symbolics: Symbolics
+using Test
+
+# Which equations of motion can be averaged, and what the averaging does to a power of a
+# variable. See https://github.com/QuantumEngineeredSystems/HarmonicBalance.jl/issues/451
+
+@testset "non-polynomial nonlinearity" begin
+    # these used to be silently dropped, returning the harmonic equations of the linear
+    # oscillator instead of erroring
+    @variables α, ω0, F, γ, ω, t, x(t)
+
+    for nonlinearity in [α * sin(x), α * exp(x), α / x, α * sqrt(x), α * x^(-2)]
+        diff_eq = DifferentialEquation(
+            d(x, t, 2) + ω0^2 * x + γ * d(x, t) + nonlinearity ~ F * cos(ω * t), x
+        )
+        add_harmonic!(diff_eq, x, ω)
+        # both entry points share the same validator
+        @test_throws ArgumentError get_harmonic_equations(diff_eq)
+        @test_throws ArgumentError get_krylov_equations(diff_eq; order=1)
+    end
+
+    # a polynomial nonlinearity of high order is fine, even though a single-harmonic
+    # ansatz projects an even power onto nothing
+    diff_eq = DifferentialEquation(
+        d(x, t, 2) + ω0^2 * x + γ * d(x, t) + α * x^10 ~ F * cos(ω * t), x
+    )
+    add_harmonic!(diff_eq, x, ω)
+    @test length(get_harmonic_equations(diff_eq; jacobian=false).equations) == 2
+end
+
+@testset "polynomial nonlinearity x^n" begin
+    # `x^n` is valid input for every n; whether the term shows up in the harmonic
+    # equations is decided by the harmonics of the ansatz, not by the order of the power.
+    @variables α, ω, t, x(t)
+
+    # the α-part of the harmonic equations of `d(x,t,2) + α*x^n ~ 0`: drop ω and the
+    # slow-flow derivatives, then set α = 1 and the harmonic variables to 2, 3, 4, ...
+    function nonlinear_part(n, harmonics)
+        diff_eq = DifferentialEquation(d(x, t, 2) + α * x^n ~ 0, x)
+        for harmonic in harmonics
+            add_harmonic!(diff_eq, x, harmonic)
+        end
+        harmonic_eq = get_harmonic_equations(diff_eq; jacobian=false)
+        vars = get_variables(harmonic_eq)
+        T = get_independent_variables(harmonic_eq)[1]
+        rules = Dict{Any,Any}(ω => 0, α => 1)
+        for (i, var) in enumerate(vars)
+            rules[var] = i + 1
+            rules[d(var, T)] = 0
+        end
+        return [
+            Symbolics.value(Symbolics.substitute(eq.lhs - eq.rhs, rules)) for
+            eq in harmonic_eq.equations
+        ]
+    end
+
+    # An odd power feeds back into ω. The cos(ωt) component of (u*cos(ωt) + v*sin(ωt))^n
+    # is binomial(n, (n-1)/2) / 2^(n-1) * u * (u^2 + v^2)^((n-1)/2), and the sin(ωt) one
+    # is the same with u and v swapped. Here (u, v) = (2, 3), so u^2 + v^2 = 13.
+    for n in 3:2:9
+        cₙ = binomial(n, (n - 1) ÷ 2)//2^(n - 1)
+        power = 13^((n - 1) ÷ 2)
+        @test nonlinear_part(n, [ω]) == [cₙ * 2 * power, cₙ * 3 * power]
+    end
+
+    # An even power only generates 0, 2ω, 4ω, ..., which a single-harmonic ansatz
+    # projects onto nothing: the harmonic equations are those of the linear oscillator.
+    for n in 2:2:10
+        @test all(iszero, nonlinear_part(n, [ω]))
+    end
+
+    # It does contribute once the harmonics it generates are part of the ansatz. Adding
+    # 2ω blows up quickly with n (n = 10 takes minutes), the zero harmonic stays cheap.
+    for n in [2, 4]
+        @test !all(iszero, nonlinear_part(n, [ω, 2ω]))
+    end
+    for n in [2, 4, 10]
+        @test !all(iszero, nonlinear_part(n, [0, ω]))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,10 @@ if GROUP in ("All", "Core")
         include("HarmonicVariable.jl")
     end
 
+    @testset "Harmonic equations" begin
+        include("HarmonicEquation.jl")
+    end
+
     @testset "Krylov-Bogoliubov" begin
         include("krylov.jl")
     end


### PR DESCRIPTION
Closes #451

`α*sin(x)`, `α*exp(x)` and `α/x` were silently dropped, so `get_harmonic_equations` handed back the equations of the plain linear oscillator with no sign that most of the input had gone missing. The harmonic ansatz turns those terms into something that isn't a finite Fourier series, `get_independent` returns 0 for them during the projection, and they disappear.

The pre-flight `is_harmonic` check couldn't catch it, because it reasons about time dependence: `get_variables(sin(x(t)))` yields `x(t)` and never `t`, so such an equation looks free of time dependence and sails through.

`assert_averageable` now gates `harmonic_ansatz`, combining the old harmonicity check with QuestBase's new `nonpolynomial_terms` and naming the offending terms. `get_krylov_equations` calls it before `rearrange_standard!`, since rearranging can move a variable into a denominator and turn an acceptable equation into a rejected one.

Even powers are a separate story and are deliberately still accepted. `x^4` and `x^10` genuinely contribute nothing to a single-harmonic ansatz, since they only generate `0, 2ω, 4ω, …`. The docs now say that, and which harmonics to add to see their effect.