### PR TITLE
perf: stop simplifying the slow-flow equations twice before averaging

### DIFF
--- a/src/HarmonicBalance.jl
+++ b/src/HarmonicBalance.jl
@@ -55,16 +55,16 @@ using Reexport: @reexport
 @reexport using HarmonicSteadyState
 
 # Precompilation setup
-# using PrecompileTools: @setup_workload, @compile_workload
-# @setup_workload begin
-#     # Putting some things in `@setup_workload` instead of `@compile_workload` can reduce the size of the
-#     # precompile file and potentially make loading faster.
-#     @compile_workload begin
-#         # all calls in this block will be precompiled, regardless of whether
-#         # they belong to your package or not (on Julia 1.8 and higher)
-#         include("precompilation.jl")
-#     end
-# end
+using PrecompileTools: @setup_workload, @compile_workload
+@setup_workload begin
+    # Putting some things in `@setup_workload` instead of `@compile_workload` can reduce the size of the
+    # precompile file and potentially make loading faster.
+    @compile_workload begin
+        # all calls in this block will be precompiled, regardless of whether
+        # they belong to your package or not (on Julia 1.8 and higher)
+        include("precompilation.jl")
+    end
+end
 
 # symbolics equations
 export @variables

--- a/src/krylov-bogoliubov.jl
+++ b/src/krylov-bogoliubov.jl
@@ -59,9 +59,10 @@ function get_krylov_equations(
     eom = slow_flow(eom; fast_time=fast_time, slow_time=slow_time, degree=2)
 
     rearrange!(eom, d(get_variables(eom), slow_time))
-    eom.equations = Symbolics.expand.(Symbolics.simplify.(eom.equations))
-    eom.equations = Symbolics.expand.(Symbolics.simplify.(eom.equations))
-    #^ need it two times to get it completely simplified due to some weird bug in Symbolics.jl
+    # `average` works term by term, so a flat sum of products is enough. A full
+    # `Symbolics.simplify` here also cancels the fraction, but its cost explodes with the
+    # number of harmonics; `simplify_fractions` below does the cancelling instead.
+    eom.equations = Symbolics.expand.(eom.equations)
 
     if order == 1
         average!(eom, fast_time)
@@ -83,6 +84,10 @@ function get_krylov_equations(
     end
 
     change_convention!(eom, slow_time)
+    # averaging has removed the fast time, so cancelling `rearrange!`'s denominator is cheap here
+    eom.equations = [
+        Symbolics.simplify_fractions(Num(eq.lhs)) ~ eq.rhs for eq in eom.equations
+    ]
     return eom
 end
 function proper_krylov_system(diff_eom::QuestBase.DifferentialEquation, order::Int)
@@ -167,10 +172,10 @@ end
 
 function take_trig_integral(x::BasicSymbolic, ω, t)
     if isdiv(x)
+        # termwise integration leaves the denominator alone, so it goes back as is; `expand`
+        # is enough to flatten for the averaging that follows
         arg_num = Symbolics.arguments(x.num)
-        return Symbolics.simplify(
-            Symbolics.expand(sum(take_trig_integral.(arg_num, ω, t)) * ω)
-        ) / (x.den * ω)
+        return Symbolics.expand(sum(take_trig_integral.(arg_num, ω, t))) / x.den
     else
         all_terms = get_all_terms(Num(x))
         trigs = filter(z -> is_trig(z), all_terms)

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -13,6 +13,9 @@ add_harmonic!(dEOM, x, ω)
 
 harmonic_eq = get_harmonic_equations(dEOM; slow_time=T, fast_time=t);
 
+get_krylov_equations(dEOM; order=1)
+get_krylov_equations(dEOM; order=2)
+
 # fixed = (Ω => 1.0, γ => 1e-2, λ => 5e-2, F => 0, α => 1.0, η => 0.3, θ => 0, ψ => 0)
 # varied = ω => range(0.9, 1.1, 20)
 # res = get_steady_states(harmonic_eq, varied, fixed; show_progress=false)


### PR DESCRIPTION
Depends on QuantumEngineeredSystems/QuestBase.jl#82 (block-diagonal solve and the `declare_variable` change).

`get_krylov_equations` ran `Symbolics.expand.(Symbolics.simplify.(...))` twice over the slow-flow equations, on the grounds that once was not enough to fully simplify them. What the second pass actually bought was the cancellation of the denominator `rearrange!` leaves behind, and `Symbolics.simplify` is a poor way to get it: its cost explodes with the number of harmonics.

`average` works term by term, so a flat sum of products is all it needs. A single `expand` gives that. The denominator is cancelled once at the end with `simplify_fractions`, after averaging has removed the fast time and the expressions are small.

`take_trig_integral` multiplied its numerator by ω and divided the denominator by the same ω, then called `simplify` to undo it. Termwise integration leaves the denominator alone, so it goes back as it came.

Together with the QuestBase changes, `get_krylov_equations` over the test systems goes from **1412 MiB to 925 MiB**, and `get_harmonic_equations` from **351 MiB to 164 MiB**.

The precompile workload is re-enabled (it was commented out because `declare_variable`'s `@eval` made it impossible) with the two `get_krylov_equations` calls added.
