### PR TITLE
Make the rearranged Jacobian opt-in

### DIFF
--- a/src/HarmonicEquation.jl
+++ b/src/HarmonicEquation.jl
@@ -148,6 +148,12 @@ the independent variable of `diff_eom`.
 By default, all products of order > 1 of `slow_time`-derivatives are dropped, which means
 the equations are linear in the time-derivatives.
 
+`explicit_jacobian` fills in the symbolic Jacobian of the rearranged system, see
+[`add_jacobian!`](@ref). It defaults to `false`: stability analysis evaluates the Jacobian
+implicitly and never reads this field, while deriving it needs a symbolic mass-matrix
+inversion that dominates the cost of this function on larger systems. Pass
+`explicit_jacobian=true` to inspect the matrix, or call [`get_Jacobian`](@ref) on the result.
+
 # Example
 ```julia-repl
 julia> @variables t, x(t), ω0, ω, F;
@@ -181,7 +187,7 @@ function get_harmonic_equations(
     fast_time=nothing,
     slow_time=nothing,
     degree=2,
-    jacobian=true,
+    explicit_jacobian=false,
 )
     slow_time = isnothing(slow_time) ? (@variables T; T) : slow_time
     fast_time = isnothing(fast_time) ? get_independent_variables(diff_eom)[1] : fast_time
@@ -198,7 +204,7 @@ function get_harmonic_equations(
     # drop higher powers of the first-order derivatives
     eom = drop_powers(eom, d(get_variables(eom), slow_time), 2)
 
-    jacobian == true ? add_jacobian!(eom) : nothing
+    explicit_jacobian == true ? add_jacobian!(eom) : nothing
     return eom
 end
 

--- a/src/Jacobian.jl
+++ b/src/Jacobian.jl
@@ -23,13 +23,14 @@ $(SIGNATURES)
 Fill in the symbolic Jacobian of `eom`, keeping the placeholder when deriving it symbolically
 is too expensive.
 
+This is opt-in, for inspecting the matrix. Stability analysis does not use it: it evaluates
+the Jacobian implicitly, solving for the derivatives numerically once the parameters have
+values, which agrees with this matrix at every steady state and stays cheap on systems where
+this one does not.
+
 [`get_Jacobian`](@ref) first rearranges the system so the derivatives stand alone on one
 side, which is a symbolic linear solve. That solve grows combinatorially with the size of
-the system: a van der Pol ansatz in three harmonics never finishes it. The placeholder
-Jacobian is what tells `HarmonicSteadyState` to evaluate the Jacobian implicitly instead,
-solving the same system numerically once the parameters have values, at a constant cost per
-point. Falling back to it costs a little time per solution and buys back a build that
-terminates.
+the system: a van der Pol ansatz in three harmonics is already prohibitive.
 """
 function add_jacobian!(eom::HarmonicEquation)
     jacobian = try

--- a/test/API.jl
+++ b/test/API.jl
@@ -40,6 +40,6 @@ end
     diff_eq = DifferentialEquation(eqs, [x])
 
     add_harmonic!(diff_eq, x, ω)
-    harmonic_eq = get_harmonic_equations(diff_eq; jacobian=false)
+    harmonic_eq = get_harmonic_equations(diff_eq; explicit_jacobian=false)
     @test hasnan(harmonic_eq.jacobian)
 end

--- a/test/HarmonicEquation.jl
+++ b/test/HarmonicEquation.jl
@@ -26,7 +26,7 @@ using Test
         d(x, t, 2) + ω0^2 * x + γ * d(x, t) + α * x^10 ~ F * cos(ω * t), x
     )
     add_harmonic!(diff_eq, x, ω)
-    @test length(get_harmonic_equations(diff_eq; jacobian=false).equations) == 2
+    @test length(get_harmonic_equations(diff_eq; explicit_jacobian=false).equations) == 2
 end
 
 @testset "polynomial nonlinearity x^n" begin
@@ -41,7 +41,7 @@ end
         for harmonic in harmonics
             add_harmonic!(diff_eq, x, harmonic)
         end
-        harmonic_eq = get_harmonic_equations(diff_eq; jacobian=false)
+        harmonic_eq = get_harmonic_equations(diff_eq; explicit_jacobian=false)
         vars = get_variables(harmonic_eq)
         T = get_independent_variables(harmonic_eq)[1]
         rules = Dict{Any,Any}(ω => 0, α => 1)


### PR DESCRIPTION
`get_harmonic_equations` derived the Jacobian of the rearranged system on every call. The rearrangement is a symbolic mass-matrix inversion whose cost grows combinatorially with the number of harmonics, and on larger systems it dominates the runtime of the whole function. A van der Pol ansatz in three harmonics is already prohibitive, and a two-tone Duffing with nonlinear damping produces a 366,698-node expression that LLVM then needs about ten minutes to compile on first use.

Nothing in the stability analysis reads the field. `HarmonicSteadyState` evaluates the Jacobian implicitly, solving for the derivatives numerically once the parameters have values. That agrees with the rearranged matrix at every steady state, which is the only place the Jacobian is ever evaluated: away from one the two differ by `∂(M⁻¹)/∂u ⋅ f(u)`, which vanishes when `f(u) = 0`.

So deriving the matrix becomes something you ask for when you want to look at it:

- `jacobian` is renamed to `explicit_jacobian` and now defaults to `false`
- `get_Jacobian(eom)` remains available for computing it on demand

## Breaking

This is a breaking change on two levels.

The kwarg rename is loud: `get_harmonic_equations(deq; jacobian=true)` now raises a `MethodError` rather than silently doing something different. That is deliberate, and it covers everyone who passed the kwarg explicitly.

The default flip is quiet, and worth stating plainly: code that called `get_harmonic_equations(deq)` with no kwarg and then read `harmonic_eq.jacobian` used to get a filled symbolic matrix and now gets the NaN placeholder, with no error. There is no shim for that case; the migration is `explicit_jacobian=true` or `get_Jacobian(harmonic_eq)`.

Note that the placeholder was already the outcome whenever the symbolic solve exceeded the Bareiss budget, so callers reading that field already had to handle it.

## Testing

Full suite passes. The four call sites in the test suite that passed `jacobian=` were updated.
